### PR TITLE
Solve challenge two

### DIFF
--- a/src/estimator.js
+++ b/src/estimator.js
@@ -10,7 +10,8 @@
 //   timeToElapse: 58,
 //   reportedCases: 674,
 //   population: 66622705,
-//   t
+//   totalHospitalBeds: 1380614
+//  }
 
 import { generateImpactData } from './util/calculations';
 

--- a/src/util/calculations.js
+++ b/src/util/calculations.js
@@ -16,7 +16,9 @@ export const getProjectedNumbersByPeriodType = (
 };
 
 export const generateImpactData = (
-  { reportedCases, timeToElapse, periodType },
+  {
+    reportedCases, timeToElapse, periodType, totalHospitalBeds
+  },
   type
 ) => {
   const determinant = type === 'severeImpact' ? 50 : 10;
@@ -27,11 +29,15 @@ export const generateImpactData = (
     timeToElapse,
     periodType
   );
+
   const severeCasesByRequestedTime = infectionsByRequestedTime * 0.15;
+  const availableHospitalBeds = totalHospitalBeds * 0.35;
+  const hospitalBedsByRequestedTime = availableHospitalBeds - severeCasesByRequestedTime;
 
   return {
     currentlyInfected,
     infectionsByRequestedTime,
-    severeCasesByRequestedTime
+    severeCasesByRequestedTime,
+    hospitalBedsByRequestedTime
   };
 };


### PR DESCRIPTION
# Solve challenge two

- Add function to calculate the total hospital beds that are available by the requested time, this is derived with the assumption that only 35% of hospital beds are available excluding total severe cases at the same requested time

## Task from [Assessment Guide](https://drive.google.com/open?id=1UEPgYqd9Bjb1ZI6wKcu7V7KZglkHMjh4)

> ### Challenge 2
> Determine `15%` of `infectionsByRequestedTime`. This is the estimated number of severe positive
> cases that will require hospitalization to recover. Represent this as `severeCasesByRequestedTime` and make it a part of your estimation output. 
> 
> Given `severeCasesByRequestedTime`, determine the number of available beds. On average, 65% of hospital beds are already occupied by patients and many hospitals usually are at 90% or 95% capacity. We want to expect only a `35%` bed availability in hospitals for severe COVID-19 positive patients.
> 
> Based on the above, the `totalHospitalBeds` input data, and your `severeCasesByRequestedTime`,
> estimate the number of available hospital beds for severe COVID-19 positive patients. E.g `23` (meaning only 23 hospital beds will be available), or `-350` (meaning there'll be a shortage of 350 beds for severe patients after hospitals are full to capacity)
> 
> Represent your beds computation as `hospitalBedsByRequestedTime` and make it a part of your
> estimation output.