### PR TITLE
Solve challenge three

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,21 @@
     "lint": "eslint ./src/",
     "lint:fix": "eslint ./src/ --fix"
   },
-  "dependencies": {},
+  "dependencies": {
+    "big.js": "^5.2.2"
+  },
   "devDependencies": {
+    "@actions/core": "^1.2.3",
+    "@actions/github": "^2.1.1",
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
+    "@lhci/cli": "0.3.x",
+    "axios": "^0.19.2",
     "babel-jest": "^25.2.6",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.20.1",
     "jest": "^25.2.7",
-    "@actions/core": "^1.2.3",
-    "@actions/github": "^2.1.1",
-    "@lhci/cli": "0.3.x",
-    "axios": "^0.19.2",
     "on-covid-19": "^0.1.3",
     "properties-reader": "^1.0.0",
     "xml2json": "^0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,11 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"


### PR DESCRIPTION
# Challenge three

 - Add calculations for `casesForICUByRequestedTime`,  `casesForVentilatorsByRequestedTime` and `dollarsInFlight` as requirent in the assesment guide, the current calculation uses `big.js` package to handle javascript big numbers to avoid wrong calculations


## Task from [Assessment Guide](https://drive.google.com/open?id=1UEPgYqd9Bjb1ZI6wKcu7V7KZglkHMjh4)

> ### Challenge 3

> Determine `5%` of `infectionsByRequestedTime`. This is the estimated number of severe positive cases that will require **ICU care**. Represent this as `casesForICUByRequestedTime` and make it a part of your estimation output.
> 
> Also, determine `2%` of `infectionsByRequestedTime`. This is the estimated number of severe positive cases that will require **ventilators**. Represent this as `casesForVentilatorsByRequestedTime` and make it a part of your estimation output.
> 
> Finally, given the estimated number of infected people by the requested time and the AVG daily income of the region, estimate how much money the economy is likely to lose over the said period. Save this as `dollarsInFlight` in your output data structure. E.g if **65%** of the region (the majority) earn **$1.5** a day, you can compute `dollarsInFlight` over a **30 day period** as:
> ```
> infectionsByRequestedTime x 0.65 x 1.5 x 30;
> ```
> > PS: At this point, you've now completed the first part of building your estimator. Did you notice that it is not accounting for deaths or recoveries over time? This is a novelty estimator, but we hope it gives you ideas of how you can use technology, open source, and research to attempt providing advocacy and advisory to any cause, including the COVID-19 pandemic.